### PR TITLE
[CN-233] add expose externally guide for Hazelcast Platform Operator

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -78,8 +78,9 @@ content:
       start_path: doc
     - url: https://github.com/hazelcast-guides/openfaas-hz-client
       start_path: doc
-    - url: https://github.com/hazelcast-guides/hazelcast-platform-operator
+    - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-expose-externally
       start_path: doc
+      branches: main
 asciidoc:
   extensions:
   - ./lib/tabs-block.js

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -49,10 +49,11 @@ Use Hazelcast with Hazelcast Platform Operator for Kubernetes.
 [.guides-grid]
 == {empty}
 
-[.guide]
-=== image:logo-kubernetes.png[] xref:hazelcast-platform-operator:ROOT:index.adoc[Getting Started with Hazelcast Platform Operator]
 
-Learn how to get started with Hazelcast Platform Operator.
+[.guide]
+=== image:logo-kubernetes.png[] xref:hazelcast-platform-operator-expose-externally:ROOT:index.adoc[Expose Externally with Hazelcast Platform Operator]
+
+Learn how to connect an external client to Hazelcast deployed on Kubernetes using Hazelcast Platform Operator.
 
 // ---------------------- Group 3
 


### PR DESCRIPTION
- Removed Getting started guide which is now part of the Hazelcast Platform Operator Docs
- Add Expose Externally feature guide